### PR TITLE
feat: xml response format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,14 @@ mod server;
 
 use std::env;
 use std::net::SocketAddr;
+use tracing::{Level};
+use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    let subscriber = FmtSubscriber::builder().with_max_level(Level::INFO).finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("setting default subscriber failed");
 
     // TODO: Better arg parsing and error handling.
     let args: Vec<String> = env::args().collect();
@@ -21,7 +25,7 @@ async fn main() {
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
 
-    tracing::info!("listening on {}", addr);
+    tracing::info!("listening on http://{}", addr);
     axum::Server::bind(&addr)
         .serve(server::app().into_make_service_with_connect_info::<SocketAddr>())
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,18 @@ mod server;
 
 use std::env;
 use std::net::SocketAddr;
-use tracing::{Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber::{filter::LevelFilter, EnvFilter, FmtSubscriber};
 
 #[tokio::main]
 async fn main() {
-    let subscriber = FmtSubscriber::builder().with_max_level(Level::INFO).finish();
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("setting default subscriber failed");
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     // TODO: Better arg parsing and error handling.
     let args: Vec<String> = env::args().collect();

--- a/src/routes/response_formats.rs
+++ b/src/routes/response_formats.rs
@@ -53,4 +53,29 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         assert!(std::str::from_utf8(&body).is_ok())
     }
+
+    #[tokio::test]
+    async fn xml() {
+        let app = routes();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/xml")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&HeaderValue::from_static(mime::TEXT_XML.as_ref()))
+        );
+
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        assert!(std::str::from_utf8(&body).is_ok())
+    }
+
 }

--- a/src/routes/response_formats.rs
+++ b/src/routes/response_formats.rs
@@ -12,7 +12,7 @@ pub fn routes() -> Router {
 async fn xml() -> impl IntoResponse {
     (
         StatusCode::OK,
-        [(header::CONTENT_TYPE, "text/xml")],
+        [(header::CONTENT_TYPE, mime::TEXT_XML.essence_str())],
         XML_PAGE,
     )
 }
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get(header::CONTENT_TYPE),
-            Some(&HeaderValue::from_static(mime::TEXT_XML.as_ref()))
+            Some(&HeaderValue::from_static(mime::TEXT_XML.essence_str()))
         );
 
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();

--- a/src/routes/response_formats.rs
+++ b/src/routes/response_formats.rs
@@ -1,9 +1,20 @@
-use axum::{response::Html, routing::get, Router};
+use axum::{response::Html, response::IntoResponse, routing::get, Router,
+  http::{StatusCode, header::{self}}};
 
 const UTF8_PAGE: &str = include_str!("../templates/utf8.html");
+const XML_PAGE: &str = include_str!("../templates/sample.xml");
 
 pub fn routes() -> Router {
     Router::new().route("/encoding/utf8", get(utf8))
+    .route("/xml", get(xml))
+}
+
+async fn xml() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/xml")],
+        XML_PAGE,
+    )
 }
 
 async fn utf8() -> Html<&'static str> {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -451,7 +451,6 @@
           HTML form that submits to <em>/post</em>
         </li>
         <li>
-          [unimplemented]
           <a href="{{ prefix }}/xml" data-bare-link="true"><code>/xml</code></a>
           Returns some XML
         </li>

--- a/src/templates/sample.xml
+++ b/src/templates/sample.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='us-ascii'?>
+
+<!--  A SAMPLE set of slides  -->
+
+<slideshow
+    title="Sample Slide Show"
+    date="Date of publication"
+    author="Yours Truly"
+    >
+
+    <!-- TITLE SLIDE -->
+    <slide type="all">
+      <title>Wake up to WonderWidgets!</title>
+    </slide>
+
+    <!-- OVERVIEW -->
+    <slide type="all">
+        <title>Overview</title>
+        <item>Why <em>WonderWidgets</em> are great</item>
+        <item/>
+        <item>Who <em>buys</em> WonderWidgets</item>
+    </slide>
+
+</slideshow>


### PR DESCRIPTION
Closes #2 

* [x] Log INFO to stdout by default (this is so we can just CMD-click on the given URL to open it in a browser)
* [x] Added `sample.xml` from Python implementation
* [x] Add testcase